### PR TITLE
Update Travis CI to only test supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.5-dev" # 3.5 development branch

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,14 @@
 Welcome to apipkg!
 ------------------------
 
-With apipkg you can control the exported namespace of a
-python package and greatly reduce the number of imports for your users.
-It is a `small pure python module`_ that works on virtually all Python
-versions, including CPython2.3 to Python3.1, Jython and PyPy.  It co-operates
-well with Python's ``help()`` system, custom importers (PEP302) and common
-command line completion tools.
+With apipkg you can control the exported namespace of a Python package and
+greatly reduce the number of imports for your users.
+It is a `small pure Python module`_ that works on CPython 2.7 and 3.4+,
+Jython and PyPy. It cooperates well with Python's ``help()`` system,
+custom importers (PEP302) and common command-line completion tools.
 
 Usage is very simple: you can require 'apipkg' as a dependency or you
-can copy paste the <200 Lines of code into your project.
+can copy paste the ~200 lines of code into your project.
 
 
 Tutorial example
@@ -32,7 +31,7 @@ The package is initialized with a dictionary as namespace.
 You need to create a ``_mypkg`` package with a ``somemodule.py``
 and ``othermodule.py`` containing the respective classes.
 The ``_mypkg`` is not special - it's a completely
-regular python package.
+regular Python package.
 
 Namespace dictionaries contain ``name: value`` mappings
 where the value may be another namespace dictionary or
@@ -53,7 +52,7 @@ loaded when they are accessed.   This means:
 * lazy loading - only what is actually needed is ever loaded
 
 * only the root "mypkg" ever needs to be imported to get
-  access to the complete functionality.
+  access to the complete functionality
 
 * the underlying modules are also accessible, for example::
 
@@ -69,7 +68,7 @@ for example ``_mypkg/apipkg.py`` in the above example.  You
 then import the ``initpkg`` function from that new place and
 are good to go.
 
-.. _`small pure python module`:
+.. _`small pure Python module`:
 .. _`apipkg.py`: https://github.com/pytest-dev/apipkg/blob/master/src/apipkg/__init__.py
 
 Feedback?

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def main():
         use_scm_version={
             'write_to': 'src/apipkg/version.py'
         },
-        url='http://github.com/pytest-dev/apipkg',
+        url='https://github.com/pytest-dev/apipkg',
         license='MIT License',
         platforms=['unix', 'linux', 'osx', 'cygwin', 'win32'],
         author='holger krekel',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import re
 from setuptools import setup, find_packages
 
 
@@ -34,8 +33,9 @@ def main():
             'Operating System :: Microsoft :: Windows',
             'Operating System :: MacOS :: MacOS X',
             'Topic :: Software Development :: Libraries',
-            # Specify the Python versions you support here. In particular, ensure
-            # that you indicate whether you support Python 2, Python 3 or both.
+            # Specify the Python versions you support here.
+            # In particular,  ensure that you indicate whether
+            # you support Python 2, Python 3 or both.
             'Programming Language :: Python',
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.7',
@@ -43,10 +43,11 @@ def main():
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
-        ],        
+        ],
         packages=find_packages('src'),
         package_dir={'': 'src'},
     )
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ def main():
         name='apipkg',
         description='apipkg: namespace control and lazy-import mechanism',
         long_description=readme(),
+        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
         setup_requires=[
             'setuptools_scm',
             'setuptools>=30.3.0',  # introduced setup.cfg metadata

--- a/src/apipkg/__init__.py
+++ b/src/apipkg/__init__.py
@@ -11,6 +11,7 @@ from types import ModuleType
 
 from .version import version as __version__
 
+
 def _py_abspath(path):
     """
     special version of abspath
@@ -122,13 +123,13 @@ class ApiModule(ModuleType):
                     self.__map__[name] = (modpath, attrname)
 
     def __repr__(self):
-        l = []
+        repr_list = []
         if hasattr(self, '__version__'):
-            l.append("version=" + repr(self.__version__))
+            repr_list.append("version=" + repr(self.__version__))
         if hasattr(self, '__file__'):
-            l.append('from ' + repr(self.__file__))
-        if l:
-            return '<ApiModule %r %s>' % (self.__name__, " ".join(l))
+            repr_list.append('from ' + repr(self.__file__))
+        if repr_list:
+            return '<ApiModule %r %s>' % (self.__name__, " ".join(repr_list))
         return '<ApiModule %r>' % (self.__name__,)
 
     def __makeattr(self, name):

--- a/src/apipkg/__init__.py
+++ b/src/apipkg/__init__.py
@@ -1,7 +1,7 @@
 """
-apipkg: control the exported namespace of a python package.
+apipkg: control the exported namespace of a Python package.
 
-see http://pypi.python.org/pypi/apipkg
+see https://pypi.python.org/pypi/apipkg
 
 (c) holger krekel, 2009 - MIT license
 """

--- a/test_apipkg.py
+++ b/test_apipkg.py
@@ -85,7 +85,7 @@ class TestRealModule:
     def test_realmodule___doc__(self):
         """test whether the __doc__ attribute is set properly from initpkg"""
         import realtest.x.module
-        print (realtest.x.module.__map__)
+        print(realtest.x.module.__map__)
         assert realtest.x.module.__doc__ == 'test module'
 
 
@@ -121,7 +121,7 @@ class TestScenarios:
         pkgdir.join('submod.py').write(py.code.Source("""
             import recmodule
             class someclass: pass
-            print (recmodule.__dict__)
+            print(recmodule.__dict__)
         """))
         monkeypatch.syspath_prepend(tmpdir)
         import recmodule
@@ -174,7 +174,7 @@ def test_parsenamespace():
         test.raises   __.test.outcome::raises
     """
     d = parsenamespace(spec)
-    print (d)
+    print(d)
     assert d == {
         'test': {'raises': '__.test.outcome::raises'},
         'path': {
@@ -364,7 +364,7 @@ def test_onfirstaccess_setsnewattr(tmpdir, monkeypatch, mode):
     if mode == 'attr':
         assert mod.newattr == 42
     elif mode == "dict":
-        print (list(mod.__dict__.keys()))
+        print(list(mod.__dict__.keys()))
         assert 'newattr' in mod.__dict__
     elif mode == "onfirst":
         assert not hasattr(mod, '__onfirstaccess__')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py26,py33,py34,jython,flakes
+envlist=py27,py34,py35,py36,jython,flakes
 
 [tox:hudson]
 sdistsrc={distshare}/apipkg-*
@@ -15,7 +15,6 @@ commands=py.test-jython []
 [testenv:flakes]
 deps=flake8
 commands=flake8
-
 
 [flake8]
 exclude=.tox/,.env/,dist/,build/,example/


### PR DESCRIPTION
PR https://github.com/pytest-dev/apipkg/pull/4 added classifiers for Python 2.7 and 3.3-3.6, so update Travis CI to only test on those versions.

Also add `python_requires` to help pip, fix some minor flake8 things, and update a couple of links to HTTPS.