### PR TITLE
Avoid iterating over a changing dict

### DIFF
--- a/src/apipkg/__init__.py
+++ b/src/apipkg/__init__.py
@@ -59,7 +59,7 @@ def initpkg(pkgname, exportdefs, attr=None, eager=False):
     sys.modules[pkgname] = mod
     # eagerload in bypthon to avoid their monkeypatching breaking packages
     if 'bpython' in sys.modules or eager:
-        for module in sys.modules.values():
+        for module in list(sys.modules.values()):
             if isinstance(module, ApiModule):
                 module.__dict__
 


### PR DESCRIPTION
create a list copy, according to https://legacy.python.org/dev/peps/pep-0469/

avoids this test failure:

============================= test session starts ==============================
platform linux -- Python 3.6.5, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
rootdir: /home/moben/Hacking/tmp/apipkg-1.4, inifile:
plugins: virtualenv-1.3.0, shutil-1.3.0, flake8-1.0.0, hypothesis-3.52.2
collected 37 items

test_apipkg.py ....................................F                     [100%]

=================================== FAILURES ===================================
___________________________ test_eagerload_on_bython ___________________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1510ecf28a90>

    def test_eagerload_on_bython(monkeypatch):
        monkeypatch.delitem(sys.modules, 'bpython', raising=False)
        apipkg.initpkg(
            'apipkg.testmodule.example.lazy',
            {'test': 'apipkg.does_not_exist'})
        monkeypatch.setitem(sys.modules, 'bpython', True)
        with pytest.raises(ImportError):
            apipkg.initpkg(
                'apipkg.testmodule.example.lazy',
>               {'test': 'apipkg.does_not_exist'})

test_apipkg.py:546:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

pkgname = 'apipkg.testmodule.example.lazy'
exportdefs = {'test': 'apipkg.does_not_exist'}, attr = {}, eager = False

    def initpkg(pkgname, exportdefs, attr=dict(), eager=False):
        """ initialize given package from the export definitions. """
        oldmod = sys.modules.get(pkgname)
        d = {}
        f = getattr(oldmod, '__file__', None)
        if f:
            f = _py_abspath(f)
        d['__file__'] = f
        if hasattr(oldmod, '__version__'):
            d['__version__'] = oldmod.__version__
        if hasattr(oldmod, '__loader__'):
            d['__loader__'] = oldmod.__loader__
        if hasattr(oldmod, '__path__'):
            d['__path__'] = [_py_abspath(p) for p in oldmod.__path__]
        if '__doc__' not in exportdefs and getattr(oldmod, '__doc__', None):
            d['__doc__'] = oldmod.__doc__
        d.update(attr)
        if hasattr(oldmod, "__dict__"):
            oldmod.__dict__.update(d)
        mod = ApiModule(pkgname, exportdefs, implprefix=pkgname, attr=d)
        sys.modules[pkgname] = mod
        # eagerload in bypthon to avoid their monkeypatching breaking packages
        if 'bpython' in sys.modules or eager:
>           for module in sys.modules.values():
E           RuntimeError: dictionary changed size during iteration

build/lib/apipkg.py:63: RuntimeError
===================== 1 failed, 36 passed in 0.22 seconds ======================