### PR TITLE
Add support for Python 3.10 and test 3.11-dev

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -38,14 +38,14 @@ jobs:
     strategy:
       matrix:
         # todo: extract from source
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10-dev"]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
         install-from: ["dist/*.whl"]
         include:
-        - python-version: 3.9
+        - python-version: "3.10"
           install-from: "-e ."
-        - python-version: 3.9
+        - python-version: "3.10"
           install-from: "."
-        - python-version: 3.9
+        - python-version: "3.10"
           install-from: "dist/*.tar.gz"
     steps:
     - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - uses: actions/download-artifact@v3
       with:
         name: dist

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # todo: extract from source
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11-dev"]
         install-from: ["dist/*.whl"]
         include:
         - python-version: "3.10"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Python sdist/wheel
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: "3.9"
     - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
 
     - name: Build package
       run: python -m build -o dist/
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: dist
         path: dist
@@ -48,9 +48,9 @@ jobs:
         - python-version: 3.9
           install-from: "dist/*.tar.gz"
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -U setuptools setuptools_scm
         pip install pytest
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dist]
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: "3.9"
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist
@@ -87,7 +87,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     needs: [dist_check, test]
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     -   id: black
         args: [--safe, --quiet]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -15,23 +15,23 @@ repos:
     -   id: debug-statements
         language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
     -   id: flake8
         language_version: python3
         additional_dependencies:
           - flake8-typing-imports==1.9.0
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.6
+    rev: v3.1.0
     hooks:
     -   id: reorder-python-imports
         args: ['--application-directories=.:src']
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.8.0
+    rev: v2.32.1
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.16.0
+    rev: v1.20.1
     hooks:
     -   id: setup-cfg-fmt
         args: [--min-py3-version=3.4]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries
 
@@ -41,7 +42,7 @@ python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 package_dir = =src
 setup_requires =
     setuptools>=30.3.0
-    setuptools_scm
+    setuptools-scm
 
 [options.packages.find]
 where = src

--- a/src/apipkg/__init__.py
+++ b/src/apipkg/__init__.py
@@ -59,7 +59,7 @@ def distribution_version(name):
 
 
 def initpkg(pkgname, exportdefs, attr=None, eager=False):
-    """ initialize given package from the export definitions. """
+    """initialize given package from the export definitions."""
     attr = attr or {}
     mod = sys.modules.get(pkgname)
 

--- a/test_apipkg.py
+++ b/test_apipkg.py
@@ -742,7 +742,7 @@ def test_aliasmodule_pytest_autoreturn_none_for_hack(monkeypatch):
 
 
 def test_aliasmodule_unicode():
-    am = apipkg.AliasModule(u"mymod", "pprint")
+    am = apipkg.AliasModule("mymod", "pprint")
     assert am
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38,py39
+envlist=py27,py34,py35,py36,py37,py38,py39,py310,py311
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Let's add the Trove classifier and change tests from `3.10-dev` to `3.10`.

---

[Python 3.11.0 beta 1 has been released 🚀](https://discuss.python.org/t/python-3-11-0b1-is-now-available/15602?u=hugovk)

This means it's now time for projects to start testing 3.11:

> We **strongly encourage** maintainers of third-party Python projects to test with 3.11 during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature complete entering the beta phase, it is possible that features may be modified or, in rare cases, deleted up until the start of the release candidate phase (Monday, 2021-08-02). Our goal is have no ABI changes after beta 4 and as few code changes as possible after 3.11.0rc1, the first release candidate. To achieve that, it will be **extremely important** to get as much exposure for 3.11 as possible during the beta phase.

On [GitHub Actions](https://github.com/actions/setup-python#available-versions-of-python), `3.11-dev` tracks the latest available alpha/beta/RC.

---

Also bump GitHub Actions versions and update pre-commit.