### PR TITLE
Drop support for EOL Python 2.7-3.6

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # todo: extract from source
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11-dev"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11-dev"]
         install-from: ["dist/*.whl"]
         include:
         - python-version: "3.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,3 @@ repos:
     rev: v1.20.1
     hooks:
     -   id: setup-cfg-fmt
-        args: [--min-py3-version=3.4]

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Welcome to apipkg !
 
 With apipkg you can control the exported namespace of a Python package and
 greatly reduce the number of imports for your users.
-It is a `small pure Python module`_ that works on CPython 2.7 and 3.4+,
+It is a `small pure Python module`_ that works on CPython 3.7+,
 Jython and PyPy. It cooperates well with Python's ``help()`` system,
 custom importers (PEP302) and common command-line completion tools.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,12 +23,8 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +34,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+python_requires = >=3.7
 package_dir = =src
 setup_requires =
     setuptools>=30.3.0

--- a/src/apipkg/__init__.py
+++ b/src/apipkg/__init__.py
@@ -5,22 +5,15 @@ see https://pypi.python.org/pypi/apipkg
 
 (c) holger krekel, 2009 - MIT license
 """
+import functools
 import os
 import sys
+import threading
 from types import ModuleType
-
-# Prior to Python 3.7 threading support was optional
-try:
-    import threading
-except ImportError:
-    threading = None
-else:
-    import functools
 
 from .version import version as __version__  # NOQA:F401
 
 
-_PY2 = sys.version_info[0] == 2
 _PRESERVED_MODULE_ATTRS = {
     "__file__",
     "__version__",
@@ -63,10 +56,7 @@ def initpkg(pkgname, exportdefs, attr=None, eager=False):
     attr = attr or {}
     mod = sys.modules.get(pkgname)
 
-    if _PY2:
-        mod = _initpkg_py2(mod, pkgname, exportdefs, attr=attr)
-    else:
-        mod = _initpkg_py3(mod, pkgname, exportdefs, attr=attr)
+    mod = _initpkg(mod, pkgname, exportdefs, attr=attr)
 
     # eagerload in bypthon to avoid their monkeypatching breaking packages
     if "bpython" in sys.modules or eager:
@@ -77,40 +67,8 @@ def initpkg(pkgname, exportdefs, attr=None, eager=False):
     return mod
 
 
-def _initpkg_py2(mod, pkgname, exportdefs, attr=None):
-    """Python 2 helper for initpkg.
-
-    In Python 2 we can't update __class__ for an instance of types.Module, and
-    imports are protected by the global import lock anyway, so it is safe for a
-    module to replace itself during import.
-
-    """
-    d = {}
-    f = getattr(mod, "__file__", None)
-    if f:
-        f = _py_abspath(f)
-    d["__file__"] = f
-    if hasattr(mod, "__version__"):
-        d["__version__"] = mod.__version__
-    if hasattr(mod, "__loader__"):
-        d["__loader__"] = mod.__loader__
-    if hasattr(mod, "__path__"):
-        d["__path__"] = [_py_abspath(p) for p in mod.__path__]
-    if hasattr(mod, "__package__"):
-        d["__package__"] = mod.__package__
-    if "__doc__" not in exportdefs and getattr(mod, "__doc__", None):
-        d["__doc__"] = mod.__doc__
-    d["__spec__"] = getattr(mod, "__spec__", None)
-    d.update(attr)
-    if hasattr(mod, "__dict__"):
-        mod.__dict__.update(d)
-    mod = ApiModule(pkgname, exportdefs, implprefix=pkgname, attr=d)
-    sys.modules[pkgname] = mod
-    return mod
-
-
-def _initpkg_py3(mod, pkgname, exportdefs, attr=None):
-    """Python 3 helper for initpkg.
+def _initpkg(mod, pkgname, exportdefs, attr=None):
+    """Helper for initpkg.
 
     Python 3.3+ uses finer grained locking for imports, and checks sys.modules before
     acquiring the lock to avoid the overhead of the fine-grained locking. This

--- a/src/apipkg/__init__.py
+++ b/src/apipkg/__init__.py
@@ -155,7 +155,7 @@ class ApiModule(ModuleType):
                 setattr(self, name, val)
         for name, importspec in importspec.items():
             if isinstance(importspec, dict):
-                subname = "{}.{}".format(self.__name__, name)
+                subname = f"{self.__name__}.{name}"
                 apimod = ApiModule(subname, importspec, implprefix)
                 sys.modules[subname] = apimod
                 setattr(self, name, apimod)
@@ -167,7 +167,7 @@ class ApiModule(ModuleType):
                     modpath = implprefix + modpath
 
                 if not attrname:
-                    subname = "{}.{}".format(self.__name__, name)
+                    subname = f"{self.__name__}.{name}"
                     apimod = AliasModule(subname, modpath)
                     sys.modules[subname] = apimod
                     if "." not in name:
@@ -183,7 +183,7 @@ class ApiModule(ModuleType):
             repr_list.append("from " + repr(self.__file__))
         if repr_list:
             return "<ApiModule {!r} {}>".format(self.__name__, " ".join(repr_list))
-        return "<ApiModule {!r}>".format(self.__name__)
+        return f"<ApiModule {self.__name__!r}>"
 
     @_synchronized
     def __makeattr(self, name, isgetattr=False):
@@ -210,7 +210,7 @@ class ApiModule(ModuleType):
             # * Only call __getattribute__ if there is a possibility something has set
             #   the attribute we're looking for since __getattr__ was called
             if threading is not None and isgetattr:
-                return super(ApiModule, self).__getattribute__(name)
+                return super().__getattribute__(name)
             raise AttributeError(name)
         else:
             result = importobj(modpath, attrname)
@@ -252,7 +252,7 @@ def AliasModule(modname, modpath, attrname=None):
         return mod[0]
 
     x = modpath + ("." + attrname if attrname else "")
-    repr_result = "<AliasModule {!r} for {!r}>".format(modname, x)
+    repr_result = f"<AliasModule {modname!r} for {x!r}>"
 
     class AliasModule(ModuleType):
         def __repr__(self):

--- a/test_apipkg.py
+++ b/test_apipkg.py
@@ -254,10 +254,10 @@ def parsenamespace(spec):
             continue
         parts = [x.strip() for x in line.split()]
         if len(parts) != 2:
-            raise ValueError("Wrong format: {!r}".format(line))
+            raise ValueError(f"Wrong format: {line!r}")
         apiname, spec = parts
         if not spec.startswith("__"):
-            raise ValueError("{!r} does not start with __".format(spec))
+            raise ValueError(f"{spec!r} does not start with __")
         apinames = apiname.split(".")
         cur = ns
         for name in apinames[:-1]:
@@ -493,7 +493,7 @@ def test_onfirstaccess_race(tmpdir, monkeypatch):
 
     class TestThread(threading.Thread):
         def __init__(self, event_start):
-            super(TestThread, self).__init__()
+            super().__init__()
             self.event_start = event_start
             self.lenl = None
 
@@ -544,7 +544,7 @@ def test_attribute_race(tmpdir, monkeypatch):
 
     class TestThread(threading.Thread):
         def __init__(self, event_start):
-            super(TestThread, self).__init__()
+            super().__init__()
             self.event_start = event_start
             self.attr = None
 
@@ -591,7 +591,7 @@ def test_import_race(tmpdir, monkeypatch):
 
     class TestThread(threading.Thread):
         def __init__(self):
-            super(TestThread, self).__init__()
+            super().__init__()
             self.importrace = None
 
         def run(self):

--- a/test_apipkg.py
+++ b/test_apipkg.py
@@ -2,20 +2,12 @@ import os.path
 import subprocess
 import sys
 import textwrap
+import threading
 import types
-
-try:
-    import threading
-except ImportError:
-    pass
 
 import pytest
 
 import apipkg
-
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
 
 #
@@ -280,7 +272,7 @@ def test_initpkg_updates_sysmodules(monkeypatch):
     monkeypatch.setitem(sys.modules, "hello", mod)
     apipkg.initpkg("hello", {"x": "os.path:abspath"})
     newmod = sys.modules["hello"]
-    assert (PY2 and newmod != mod) or (PY3 and newmod is mod)
+    assert newmod is mod
     assert newmod.x == os.path.abspath
 
 
@@ -295,7 +287,7 @@ def test_initpkg_transfers_attrs(monkeypatch):
     monkeypatch.setitem(sys.modules, "hello", mod)
     apipkg.initpkg("hello", {})
     newmod = sys.modules["hello"]
-    assert (PY2 and newmod != mod) or (PY3 and newmod is mod)
+    assert newmod is mod
     assert newmod.__file__ == os.path.abspath(mod.__file__)
     assert newmod.__version__ == mod.__version__
     assert newmod.__loader__ == mod.__loader__
@@ -319,7 +311,7 @@ def test_initpkg_overwrite_doc(monkeypatch):
     monkeypatch.setitem(sys.modules, "hello", hello)
     apipkg.initpkg("hello", {"__doc__": "sys:__doc__"})
     newhello = sys.modules["hello"]
-    assert (PY2 and newhello != hello) or (PY3 and newhello is hello)
+    assert newhello is hello
     assert newhello.__doc__ == sys.__doc__
 
 
@@ -331,7 +323,7 @@ def test_initpkg_not_transfers_not_existing_attrs(monkeypatch):
     monkeypatch.setitem(sys.modules, "hello", mod)
     apipkg.initpkg("hello", {})
     newmod = sys.modules["hello"]
-    assert (PY2 and newmod != mod) or (PY3 and newmod is mod)
+    assert newmod is mod
     assert newmod.__file__ == os.path.abspath(mod.__file__)
     assert not hasattr(newmod, "__path__")
     assert not hasattr(newmod, "__package__") or mod.__package__ is None
@@ -344,7 +336,7 @@ def test_initpkg_not_changing_jython_paths(monkeypatch):
     monkeypatch.setitem(sys.modules, "hello", mod)
     apipkg.initpkg("hello", {})
     newmod = sys.modules["hello"]
-    assert (PY2 and newmod != mod) or (PY3 and newmod is mod)
+    assert newmod is mod
     assert newmod.__file__.startswith("__pyclasspath__")
     unchanged, changed = newmod.__path__
     assert changed != "ichange"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38,py39,py310,py311
+envlist=py37,py38,py39,py310,py311
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.7   | 3.7.13 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
| 3.5   | 3.5.10 | 2015-09-13 | 2020-09-13 |
| 3.4   | 3.4.10 | 2014-03-16 | 2019-03-18 |
| 3.3   | 3.3.7  | 2012-09-29 | 2017-09-29 |
| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 |